### PR TITLE
PRI-1190 [DM] Add client_max_body_size parameter to nginx conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,3 +63,6 @@ nginx_docker_error_log:  "/var/log/nginx/error.log"
 nginx_docker_error_log_level:  warn
 nginx_docker_custom_log_fields: []          # can be any nginx variable e.g. realip_remote_addr, http_x_customheader
 nginx_docker_json_log_format_enable: false
+
+# Client request configuration parameters
+nginx_docker_client_max_body_size: 15M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,4 +65,4 @@ nginx_docker_custom_log_fields: []          # can be any nginx variable e.g. rea
 nginx_docker_json_log_format_enable: false
 
 # Client request configuration parameters
-nginx_docker_client_max_body_size: 15M
+nginx_docker_client_max_body_size: 1M

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -55,5 +55,7 @@ http {
 
 {% endif -%}
 
+    client_max_body_size {{ nginx_docker_client_max_body_size }}
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
As a requirement for PRI-1173, we need to parametrise `client_max_body_size` configuration option in nginx.

This change creates a variable for the same which can be used to provide desired value.
Setting it to 1M as default.